### PR TITLE
Enable the Detection of Errors that Occur During the Invocation of Ethereum Smart Contract Functions

### DIFF
--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/bitcoin/BitcoinAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/bitcoin/BitcoinAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System - University of Stuttgart
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System - University of Stuttgart
  * Author: Ghareeb Falazi
  *
  * This program and the accompanying materials are made available under the
@@ -274,7 +274,7 @@ public class BitcoinAdapter extends AbstractAdapter {
     }
 
     @Override
-    public CompletableFuture<Transaction> invokeSmartContract(String smartContractPath, String functionIdentifier, List<Parameter> inputs, List<Parameter> outputs, double requiredConfidence) throws NotSupportedException, ParameterException {
+    public CompletableFuture<Transaction> invokeSmartContract(String smartContractPath, String functionIdentifier, List<Parameter> inputs, List<Parameter> outputs, double requiredConfidence, long timeoutMillis) throws NotSupportedException, ParameterException {
         throw new NotSupportedException("Bitcoin does not support smart contract function invocations!");
     }
 

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapter.java
@@ -639,15 +639,14 @@ public class EthereumAdapter extends AbstractAdapter {
     private CompletableFuture<TransactionReceipt> waitUntilTransactionIsMined(final String txHash, final long timeOutMillis)
             throws CompletionException {
         final CompletableFuture<TransactionReceipt> result = new CompletableFuture<>();
-        final BigInteger TIMEOUT = BigInteger.valueOf(timeOutMillis);
-        final BigInteger START_TIME_MILLIS = BigInteger.valueOf((new Date()).getTime());
+        final long START_TIME_MILLIS = (new Date()).getTime();
 
         final Disposable subscription = web3j.blockFlowable(false).subscribe(ethBlock -> {
             try {
-                BigInteger blockTime = ethBlock.getBlock().getTimestamp();
+                long currentTimeMillis = (new Date()).getTime();
 
                 // if the time passed since we started is longer than the timeout
-                if (blockTime.subtract(START_TIME_MILLIS).compareTo(TIMEOUT) >= 0) {
+                if (currentTimeMillis - START_TIME_MILLIS >= timeOutMillis) {
                     TimeoutException exception =
                             new TimeoutException("Timeout is reached before transaction is mined!", txHash, 0.0);
                     result.completeExceptionally(exception);

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System - University of Stuttgart
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System - University of Stuttgart
  * Author: Ghareeb Falazi
  *
  * This program and the accompanying materials are made available under the
@@ -29,6 +29,7 @@ import blockchains.iaas.uni.stuttgart.de.exceptions.BlockchainNodeUnreachableExc
 import blockchains.iaas.uni.stuttgart.de.exceptions.InvalidScipParameterException;
 import blockchains.iaas.uni.stuttgart.de.exceptions.InvalidTransactionException;
 import blockchains.iaas.uni.stuttgart.de.exceptions.InvokeSmartContractFunctionFailure;
+import blockchains.iaas.uni.stuttgart.de.exceptions.InvokeSmartContractFunctionRevoke;
 import blockchains.iaas.uni.stuttgart.de.exceptions.NotSupportedException;
 import blockchains.iaas.uni.stuttgart.de.exceptions.ParameterException;
 import blockchains.iaas.uni.stuttgart.de.model.Occurrence;
@@ -88,7 +89,8 @@ public class FabricAdapter implements BlockchainAdapter {
             String functionIdentifier,
             List<Parameter> inputs,
             List<Parameter> outputs,
-            double requiredConfidence) throws BalException {
+            double requiredConfidence,
+            long timeoutMillis) throws BalException {
         if (outputs.size() > 1) {
             throw new ParameterException("Hyperledger Fabric supports only at most a single return value.");
         }
@@ -120,7 +122,7 @@ public class FabricAdapter implements BlockchainAdapter {
                 result.complete(resultT);
             } catch (Exception e) {
                 // exceptions at this level are invocation exceptions. They should be sent asynchronously to the client app.
-                result.completeExceptionally(new InvokeSmartContractFunctionFailure(e.getMessage()));
+                result.completeExceptionally(new InvokeSmartContractFunctionRevoke(e.getMessage()));
             }
         } catch (Exception e) {
             // this is a synchronous exception.

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapter.java
@@ -122,7 +122,7 @@ public class FabricAdapter implements BlockchainAdapter {
                 result.complete(resultT);
             } catch (Exception e) {
                 // exceptions at this level are invocation exceptions. They should be sent asynchronously to the client app.
-                result.completeExceptionally(new InvokeSmartContractFunctionRevoke(e.getMessage()));
+                result.completeExceptionally(new InvokeSmartContractFunctionFailure(e.getMessage()));
             }
         } catch (Exception e) {
             // this is a synchronous exception.

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/interfaces/BlockchainAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/interfaces/BlockchainAdapter.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2018-2019 Institute for the Architecture of Application System -
+ * Copyright (c) 2018-2022 Institute for the Architecture of Application System -
  * University of Stuttgart
  * Author: Ghareeb Falazi
  *
@@ -83,7 +83,8 @@ public interface BlockchainAdapter {
      * @param inputs             the input parameters of the function to be invoked
      * @param outputs            the output parameters of the function to be invoked
      * @param requiredConfidence the degree-of-confidence required to be achieved before sending a callback message to the invoker.
-     * @return a completable future that emits a new transaction object holding the result of the invocation.
+     * @return a completable future that emits a new transaction object holding the result of the invocation, or finishes exceptionally
+     * indicating a failed invocation.
      * @throws NotSupportedException if the underlying blockchain system does not support smart contracts.
      */
     CompletableFuture<Transaction> invokeSmartContract(

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/interfaces/BlockchainAdapter.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/adaptation/interfaces/BlockchainAdapter.java
@@ -92,7 +92,8 @@ public interface BlockchainAdapter {
             String functionIdentifier,
             List<Parameter> inputs,
             List<Parameter> outputs,
-            double requiredConfidence
+            double requiredConfidence,
+            long timeoutMillis
     ) throws BalException;
 
     /**

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/exceptions/InvokeSmartContractFunctionRevoke.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/exceptions/InvokeSmartContractFunctionRevoke.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019-2022 Institute for the Architecture of Application System - University of Stuttgart
+ * Copyright (c) 2022 Institute for the Architecture of Application System - University of Stuttgart
  * Author: Ghareeb Falazi
  *
  * This program and the accompanying materials are made available under the
@@ -8,21 +8,22 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
+
 package blockchains.iaas.uni.stuttgart.de.exceptions;
 
 import com.github.arteam.simplejsonrpc.core.annotation.JsonRpcError;
 
-@JsonRpcError(code = ExceptionCode.InvocationError, message = "The smart contract function invocation failed.")
-public class InvokeSmartContractFunctionFailure extends BalException {
-    public InvokeSmartContractFunctionFailure() {
+@JsonRpcError(code = ExceptionCode.ExecutionError, message = "The execution of the smart contract function resulted in an error.")
+public class InvokeSmartContractFunctionRevoke extends  BalException{
+    public InvokeSmartContractFunctionRevoke() {
     }
 
-    public InvokeSmartContractFunctionFailure(String message) {
+    public InvokeSmartContractFunctionRevoke(String message) {
         super(message);
     }
 
     @Override
     public int getCode() {
-        return ExceptionCode.InvocationError;
+        return ExceptionCode.ExecutionError;
     }
 }

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/management/BlockchainManager.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/management/BlockchainManager.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System -
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System -
  * University of Stuttgart
  * Author: Ghareeb Falazi
  *
@@ -385,7 +385,6 @@ public class BlockchainManager {
 
         final AdapterManager adapterManager = AdapterManager.getInstance();
         final double minimumConfidenceAsProbability = requiredConfidence / 100.0;
-
         final BlockchainAdapter adapter = adapterManager.getAdapter(blockchainIdentifier);
         final CompletableFuture<Transaction> future = adapter.invokeSmartContract(smartContractPath,
                 functionIdentifier, inputs, outputs, minimumConfidenceAsProbability);
@@ -402,10 +401,11 @@ public class BlockchainManager {
                             CallbackManager.getInstance().sendCallback(callbackUrl,
                                     ScipMessageTranslator.getAsynchronousErrorResponseMessage(
                                             correlationId,
-                                            new TransactionNotFoundException("The transaction associated with an function invocation is invalidated after it was mined.")));
+                                            new TransactionNotFoundException("The transaction associated with a function invocation is invalidated after it was mined.")));
                         }
-                    } else
+                    } else {
                         log.info("resulting transaction is null");
+                    }
                 }).
                 exceptionally((e) -> {
                     log.info("Failed to invoke smart contract function. Reason: {}", e.getMessage());

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/model/TransactionState.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/model/TransactionState.java
@@ -20,6 +20,8 @@ public enum TransactionState {
     CONFIRMED,
     NOT_FOUND,
     INVALID,
+    // When a smart contract function fails although a transaction is recorded (relevant for Ethereum-like BCs)
+    ERRORED,
     // indicates that a successful read-only function invocation occurred
     RETURN_VALUE
 }

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/model/TransactionState.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/model/TransactionState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System -
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System -
  * University of Stuttgart
  * Author: Ghareeb Falazi
  *
@@ -20,6 +20,6 @@ public enum TransactionState {
     CONFIRMED,
     NOT_FOUND,
     INVALID,
-    // transactions which are only place holders for read-only function invocation result
+    // indicates that a successful read-only function invocation occurred
     RETURN_VALUE
 }

--- a/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapterTest.java
+++ b/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System - University of Stuttgart
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System - University of Stuttgart
  * Author: Ghareeb Falazi
  *
  * This program and the accompanying materials are made available under the
@@ -101,12 +101,12 @@ class EthereumAdapterTest {
         String argument = new BigInteger(bytes).toString(16);
         List<Parameter> inputs = Collections.singletonList(new Parameter("publicKey", BYTES_TYPE, argument));
         List<Parameter> outputs = Collections.emptyList();
-        LinearChainTransaction init = (LinearChainTransaction) this.adapter.invokeSmartContract(smartContractPath, functionIdentifier, inputs, outputs, REQUIRED_CONFIDENCE).get();
+        LinearChainTransaction init = (LinearChainTransaction) this.adapter.invokeSmartContract(smartContractPath, functionIdentifier, inputs, outputs, REQUIRED_CONFIDENCE, 0).get();
         log.info("initial transaction {}", init.getTransactionHash());
         functionIdentifier = "getPublicKey";
         inputs = Collections.singletonList(new Parameter("ethereumAddress", ADDRESS_TYPE, "0x90645Dc507225d61cB81cF83e7470F5a6AA1215A"));
         outputs = Collections.singletonList(new Parameter("return", BYTES_TYPE, null));
-        Transaction result = this.adapter.invokeSmartContract(smartContractPath, functionIdentifier, inputs, outputs, REQUIRED_CONFIDENCE).get();
+        Transaction result = this.adapter.invokeSmartContract(smartContractPath, functionIdentifier, inputs, outputs, REQUIRED_CONFIDENCE, 0).get();
         String value = result.getReturnValues().get(0).getValue();
         log.debug(value);
         String retrievedMessage = new String(new BigInteger(value, 16).toByteArray(), StandardCharsets.UTF_8);

--- a/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapterTest.java
+++ b/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/ethereum/EthereumAdapterTest.java
@@ -126,6 +126,7 @@ class EthereumAdapterTest {
     }
 
     @Test
+    @Disabled
     void testBlockNumbers() throws IOException {
         LocalDateTime from = LocalDateTime.of(2019, 12, 27, 10, 50);
         LocalDateTime to = LocalDateTime.of(2019, 12, 27, 10, 56);
@@ -137,6 +138,7 @@ class EthereumAdapterTest {
     }
 
     @Test
+    @Disabled
     void testExtremeBlockNumbers() throws IOException {
         LocalDateTime from = LocalDateTime.of(2001, 12, 27, 10, 50);
         LocalDateTime to = LocalDateTime.of(2029, 12, 27, 10, 56);

--- a/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapterTest.java
+++ b/src/test/java/blockchains/iaas/uni/stuttgart/de/adaptation/adapters/fabric/FabricAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Institute for the Architecture of Application System - University of Stuttgart
+ * Copyright (c) 2019-2022 Institute for the Architecture of Application System - University of Stuttgart
  * Author: Ghareeb Falazi
  *
  * This program and the accompanying materials are made available under the
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 /**
  * In order for this test to succeed:
@@ -77,14 +76,16 @@ class FabricAdapterTest {
                         new Parameter("colour", "string", "Black"),
                         new Parameter("owner", "string", "Ghareeb")),
                 Collections.emptyList(),
-                1.0).get();
+                1.0,
+                0).get();
 
         Transaction result = this.adapter.invokeSmartContract(
                 path,
                 "queryAllCars",
                 new ArrayList<>(),
                 new ArrayList<>(),
-                1.0).get();
+                1.0,
+                0).get();
         String value = result.getReturnValues().get(0).getValue();
         log.debug("Looking for Id: " + id);
         Assertions.assertTrue(value.contains(id));


### PR DESCRIPTION
- When an Ethereum smart contract function reports an error, it is reported asynchronously to the invoker according to the SCIP protocol.
- Ensure the transaction that holds the request to invoke a write-access SC function is mined before trying to ensure its durability. Waiting for mining the transaction lasts no more than the specified timeout.
- Solves #11 
- Related to #8 