### PR TITLE
Remove ProcessInstanceID from Camunda Message

### DIFF
--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/scip/bindings/camunda/CamundaBinding.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/scip/bindings/camunda/CamundaBinding.java
@@ -87,7 +87,6 @@ public class CamundaBinding implements AbstractBinding {
             Message message = Message
                     .builder()
                     .messageName(messageName)
-                    .processInstanceId(exception.getCorrelationIdentifier())
                     .processVariables(variables).build();
 
             sendCamundaMessage(message, endpointUrl);
@@ -118,7 +117,6 @@ public class CamundaBinding implements AbstractBinding {
         final Message message = Message
                 .builder()
                 .messageName("result_" + correlationIdentifier)
-                .processInstanceId(correlationIdentifier)
                 .processVariables(variables)
                 .build();
 

--- a/src/main/java/blockchains/iaas/uni/stuttgart/de/scip/bindings/camunda/model/Message.java
+++ b/src/main/java/blockchains/iaas/uni/stuttgart/de/scip/bindings/camunda/model/Message.java
@@ -25,8 +25,6 @@ import lombok.extern.jackson.Jacksonized;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Message {
     @NonNull
-    private String processInstanceId;
-    @NonNull
     private String messageName;
     @NonNull
     private Map<String, Variable> processVariables;


### PR DESCRIPTION
Using the processId forces all messages in the process to have the same name, which makes problems with parallel executions (and parallel executions happen for compensating tasks.)